### PR TITLE
Write unit tests for widgets

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
 
 
 dev_dependencies:
+  network_image_mock: ^2.0.1
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
 
   cupertino_icons: ^0.1.3
-  carousel_slider: ^2.2.1
+  carousel_slider: ^4.0.0
   animations: ^1.1.2
 
 

--- a/test/screens/core/cart/cart_item_card_test.dart
+++ b/test/screens/core/cart/cart_item_card_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:sewistic_app/models/order/cart_item.dart';
+import 'package:sewistic_app/models/product/product.dart';
+import 'package:sewistic_app/screens/core/cart/cart.dart';
+import 'package:sewistic_app/screens/core/cart/widgets/cart_item_card.dart';
+import 'package:sewistic_app/services/design_options.dart';
+
+void main() {
+  Product mockProduct = Product(
+      'Mock Product Name',
+      '650',
+      'https://i2.wp.com/sewistic.com/wp-content/uploads/2020/06/deal-01-1-scaled.jpg?fit=252%2C300&ssl=1',
+      "Classic 3 Piece Deal features the Shirt & trouser stitching as per catalog design with neckline and sleeves of your choice.",
+      [
+        ClothDesignOptions.NECK_LINES(),
+        ClothDesignOptions.SLEEVES_WOMEN(),
+        ClothDesignOptions.BOTTOMS_WOMEN()
+      ],
+    );
+    
+  CartItem mockCartItem = CartItem(
+      mockProduct, 
+      ['V Neckline', 'Quarter sleeves', 'Standard Shalwar'],
+      'Sample Provided',
+      true
+    );
+
+  CartState mockCartState = CartState();
+
+  Future<void> _mountWidget(WidgetTester tester) async {
+    await mockNetworkImagesFor(() async => 
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CartItemCard(mockCartItem, mockCartState),
+      )));
+  }
+  testWidgets('Card widget is created', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder cardFinder = find.byType(Card);
+    expect(cardFinder, findsOneWidget);
+  });
+
+  testWidgets('Product name is on card', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder nameFinder = find.text('Mock Product Name');
+    expect(nameFinder, findsOneWidget);
+  });
+
+  testWidgets('Product price is on card', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder nameFinder = find.text('Rs.650');
+    expect(nameFinder, findsOneWidget);
+  });
+
+  testWidgets('Measurement option is on card', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder optionFinder = find.text('Sample Provided');
+    expect(optionFinder, findsOneWidget);
+  });
+
+  testWidgets('Design options are on card', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder optionsFinder = find.text(mockCartItem.designOptions.join(', '));
+    expect(optionsFinder, findsOneWidget);
+  });
+
+  testWidgets('Card includes the correct image', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder imageFinder = find.byType(Image);
+    expect(imageFinder, findsOneWidget);
+    NetworkImage image = (tester.widget(imageFinder) as Image).image as NetworkImage;
+    expect(image.url, mockProduct.image);
+  });
+
+  testWidgets('Checkbox has correct value', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder checkboxFinder = find.byType(Checkbox);
+    expect(checkboxFinder, findsOneWidget);
+    
+    Checkbox checkbox = tester.widget(checkboxFinder) as Checkbox;
+    expect(checkbox.value, true);
+  });
+
+}

--- a/test/screens/core/home/images_slider_test.dart
+++ b/test/screens/core/home/images_slider_test.dart
@@ -1,0 +1,39 @@
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sewistic_app/screens/core/home/widgets/image_slider.dart';
+
+void main() {
+  Future<void> _mountWidget(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Container(child: SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: Card(
+            child: ImagesSlider(),
+          ))),
+        ),
+      ));
+  }
+  
+  testWidgets('CarouselSlider widget is created', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder carouselFinder = find.byType(CarouselSlider);
+    expect(carouselFinder, findsOneWidget);
+  });
+
+  testWidgets('Contains the correct items', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder carouselFinder = find.byType(CarouselSlider);
+    expect(carouselFinder, findsOneWidget);
+
+    CarouselSlider carousel = tester.widget(carouselFinder) as CarouselSlider;
+    expect(carousel.itemCount, 1);
+
+    Image item = carousel.items[0] as Image;
+    expect(item.image.runtimeType, AssetImage);
+    expect((item.image as AssetImage).assetName, 'assets/images/cover1.jpg');
+  });
+
+}

--- a/test/screens/core/home/title_divider_test.dart
+++ b/test/screens/core/home/title_divider_test.dart
@@ -1,4 +1,3 @@
-import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sewistic_app/screens/core/home/widgets/title_divider.dart';

--- a/test/screens/core/home/title_divider_test.dart
+++ b/test/screens/core/home/title_divider_test.dart
@@ -1,0 +1,23 @@
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sewistic_app/screens/core/home/widgets/title_divider.dart';
+
+void main() {
+  Future<void> _mountWidget(WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: TitleDivider("Test Title"),));
+  }
+  
+  testWidgets('The title is rendered', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder titleFinder = find.text('Test Title');
+    expect(titleFinder, findsOneWidget);
+  });
+
+  testWidgets('The divider is rendered', (WidgetTester tester) async {
+    await _mountWidget(tester);
+    Finder dividerFinder = find.byType(Divider);
+    expect(dividerFinder, findsOneWidget);
+  });
+
+}


### PR DESCRIPTION
Wrote unit tests that verify behavior for TitleDivider, ImagesSlider, and CartItemCard widgets. Modified pubspec.yaml to add development dependency on network_image_mock, needed to test CardItemCard widget, and upgraded carousel_slider to version 4 to resolve null safety issues. All tests currently pass.

Related to issue #9.